### PR TITLE
switch to Bluebird

### DIFF
--- a/lib/xbmc-ws.js
+++ b/lib/xbmc-ws.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var Connection = require('./Connection');
 
 function connect(host, port) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "has-value": "^0.2.0",
     "jrpc-schema": "^1.1.0",
     "set-value": "^0.2.0",
-    "ws": "~0.4.31"
+    "ws": "~0.4.31",
+    "bluebird":"latest"
   },
   "devDependencies": {
     "eslint": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "has-value": "^0.2.0",
-    "jrpc-schema": "git+https://github.com/Fjuxx/node-jrpc-schema",
+    "jrpc-schema": "^1.1.0",
     "set-value": "^0.2.0",
     "ws": "~0.4.31",
     "bluebird":"latest"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "has-value": "^0.2.0",
-    "jrpc-schema": "^1.1.0",
+    "jrpc-schema": "git+https://github.com/Fjuxx/node-jrpc-schema",
     "set-value": "^0.2.0",
     "ws": "~0.4.31",
     "bluebird":"latest"


### PR DESCRIPTION
Uses the Bluebird library for Promises instead of the native NodeJS one.
To make it compatible with older versions as well.