### PR TITLE
Updated ws to version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "has-value": "^0.2.0",
     "jrpc-schema": "^2.1.0",
     "set-value": "^0.2.0",
-    "ws": "^0.7.2"
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^1.9.0"


### PR DESCRIPTION
Here is a pull request that updates ws package to the latest version (1.1.x).  The version in dependencies  now (0.7.x) still has problems installing cleanly on recent node versions due to compilation errors.

The examples directory run well against the new version version, and I've been testing my own app, which works as well. 
