### PR TITLE
Moved babel-eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "test": "make lint"
   },
   "dependencies": {
-    "babel-eslint": "^5.0.0-beta8",
     "has-value": "^0.2.0",
     "jrpc-schema": "^2.1.0",
     "set-value": "^0.2.0",
     "ws": "^0.7.2"
   },
   "devDependencies": {
-    "eslint": "^1.9.0"
+    "eslint": "^1.9.0",
+    "babel-eslint": "^5.0.0-beta8"
   }
 }


### PR DESCRIPTION
This moves babel-eslint from dependencies into devDependencies, like eslint is currently.  It shouldn't be needed by end users, and actually without this change, gives a warning on installation since eslint peer dependency is not installed.
